### PR TITLE
Replace tokens underscore with hyphen: CY-1263

### DIFF
--- a/src/main/scala/com/codacy/api/client/CodacyClient.scala
+++ b/src/main/scala/com/codacy/api/client/CodacyClient.scala
@@ -16,6 +16,9 @@ class CodacyClient(
   private implicit val errorJsonFormat: Reads[ErrorJson] = Json.reads[ErrorJson]
 
   private val tokens = Map.empty[String, String] ++
+    apiToken.map(t => "api-token" -> t) ++
+    projectToken.map(t => "project-token" -> t) ++
+    // This is deprecated and is kept for backward compatibility. It will removed in the context of CY-1272
     apiToken.map(t => "api_token" -> t) ++
     projectToken.map(t => "project_token" -> t)
 


### PR DESCRIPTION
The problem is nginx, used in k8s, by default drops all http request headers that contain the underscore char, meaning that project_token and api_token headers are not reaching the route handlers and these are failing on the authentication step.

Therefore we are changing the API tokens to use "-" instead of "_". 

More context in https://bitbucket.org/qamine/codacy-website/pull-requests/3185/