### PR TITLE
fix: Add Maven Central resolver for the `scala-logging` dependency

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers := Seq(DefaultMavenRepository, Resolver.jcenterRepo, Resolver.sonatypeRepo("releases"))
+resolvers := Seq(DefaultMavenRepository, Resolver.jcenterRepo, Resolver.sonatypeRepo("releases"), Resolver.mavenCentral)
 
 addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "14.0.1")
 


### PR DESCRIPTION
The API is failing to publish due to unresolved dependencies: https://app.circleci.com/pipelines/github/codacy/codacy-api-scala/8/workflows/1278895e-7872-4947-a296-8bfa6bc8a666/jobs/329