### PR TITLE
revert: Revert logging improvement commits [CY-2365]

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ coverageServices.sendReport(commitUUID, Language.Scala, report) match {
 - Identify new Static Analysis issues
 - Commit and Pull Request Analysis with GitHub, BitBucket/Stash, GitLab (and also direct git repositories)
 - Auto-comments on Commits and Pull Requests
-- Integrations with Slack, HipChat, Jira
+- Integrations with Slack, HipChat, Jira, YouTrack
 - Track issues in Code Style, Security, Error Proneness, Performance, Unused Code and other categories
 
 Codacy also helps keep track of Code Coverage, Code Duplication, and Code Complexity.

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7")
 scalacOptions := Seq("-deprecation", "-feature", "-unchecked", "-Ywarn-adapted-args", "-Xlint", "-Xfatal-warnings")
 
 // Runtime dependencies
-libraryDependencies ++= Seq(jodaConvert, jgit, scalajHttp, Dependencies.playJson, Dependencies.scalaLogging)
+libraryDependencies ++= Seq(jodaConvert, jgit, scalajHttp, Dependencies.playJson)
 
 // Test dependencies
 libraryDependencies ++= Seq(scalatest).map(_ % "test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,6 +2,6 @@ import sbt._
 
 object Dependencies {
 
-  val playJson = "com.typesafe.play" %% "play-json" % "2.6.10" withSources ()
-  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+  val playJson = "com.typesafe.play" %% "play-json" % "2.6.10" withSources()
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers := Seq(DefaultMavenRepository, Resolver.jcenterRepo, Resolver.sonatypeRepo("releases"), Resolver.mavenCentral)
+resolvers := Seq(DefaultMavenRepository, Resolver.jcenterRepo, Resolver.sonatypeRepo("releases"))
 
 addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "14.0.1")
 

--- a/src/main/scala/com/codacy/api/client/CodacyClient.scala
+++ b/src/main/scala/com/codacy/api/client/CodacyClient.scala
@@ -2,13 +2,13 @@ package com.codacy.api.client
 
 import play.api.libs.json._
 import com.codacy.api.util.JsonOps
-import com.typesafe.scalalogging.LazyLogging
 import scalaj.http.Http
 
-import scala.util.{Failure, Success, Try}
-
-class CodacyClient(apiUrl: Option[String] = None, apiToken: Option[String] = None, projectToken: Option[String] = None)
-    extends LazyLogging {
+class CodacyClient(
+    apiUrl: Option[String] = None,
+    apiToken: Option[String] = None,
+    projectToken: Option[String] = None
+) {
 
   private case class ErrorJson(error: String)
   private case class PaginatedResult[T](next: Option[String], values: Seq[T])
@@ -103,14 +103,9 @@ class CodacyClient(apiUrl: Option[String] = None, apiToken: Option[String] = Non
   }
 
   private def parseJson(input: String): RequestResponse[JsValue] = {
-    Try(Json.parse(input)) match {
-      case Success(json) =>
-        json
-          .validate[ErrorJson]
-          .fold(_ => SuccessfulResponse(json), apiError => FailedResponse(s"API Error: ${apiError.error}"))
-      case Failure(exception) =>
-        logger.error(s"Failed to parse API response as JSON - $input", exception)
-        FailedResponse("Failed to parse API response as JSON")
-    }
+    val json = Json.parse(input)
+    json
+      .validate[ErrorJson]
+      .fold(_ => SuccessfulResponse(json), apiError => FailedResponse(s"API Error: ${apiError.error}"))
   }
 }


### PR DESCRIPTION
This reverts the commits:
- 858437e - fix: Add Maven Central resolver for the `scala-logging` dependency [CY-2365]
- 00502fc - feature: Improve error handling when parsing API responses [CY-2365]

The `scala-logging` library is not compatible between Scala 2.10 and versions above.

[CY-2365]: https://codacy.atlassian.net/browse/CY-2365
[CY-2365]: https://codacy.atlassian.net/browse/CY-2365