### PR TITLE
fix: Revert adding a logging dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7")
 scalacOptions := Seq("-deprecation", "-feature", "-unchecked", "-Ywarn-adapted-args", "-Xlint", "-Xfatal-warnings")
 
 // Runtime dependencies
-libraryDependencies ++= Seq(jodaConvert, jgit, scalajHttp, Dependencies.playJson, Dependencies.scalaLogging)
+libraryDependencies ++= Seq(jodaConvert, jgit, scalajHttp, Dependencies.playJson)
 
 // Test dependencies
 libraryDependencies ++= Seq(scalatest).map(_ % "test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,5 @@
 import sbt._
 
 object Dependencies {
-
   val playJson = "com.typesafe.play" %% "play-json" % "2.6.10" withSources ()
-  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers := Seq(DefaultMavenRepository, Resolver.jcenterRepo, Resolver.sonatypeRepo("releases"), Resolver.mavenCentral)
+resolvers := Seq(DefaultMavenRepository, Resolver.jcenterRepo, Resolver.sonatypeRepo("releases"))
 
 addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "14.0.1")
 

--- a/src/main/scala/com/codacy/api/client/CodacyClient.scala
+++ b/src/main/scala/com/codacy/api/client/CodacyClient.scala
@@ -2,13 +2,15 @@ package com.codacy.api.client
 
 import play.api.libs.json._
 import com.codacy.api.util.JsonOps
-import com.typesafe.scalalogging.LazyLogging
 import scalaj.http.Http
 
 import scala.util.{Failure, Success, Try}
 
-class CodacyClient(apiUrl: Option[String] = None, apiToken: Option[String] = None, projectToken: Option[String] = None)
-    extends LazyLogging {
+class CodacyClient(
+    apiUrl: Option[String] = None,
+    apiToken: Option[String] = None,
+    projectToken: Option[String] = None
+) {
 
   private case class ErrorJson(error: String)
   private case class PaginatedResult[T](next: Option[String], values: Seq[T])
@@ -109,8 +111,7 @@ class CodacyClient(apiUrl: Option[String] = None, apiToken: Option[String] = Non
           .validate[ErrorJson]
           .fold(_ => SuccessfulResponse(json), apiError => FailedResponse(s"API Error: ${apiError.error}"))
       case Failure(exception) =>
-        logger.error(s"Failed to parse API response as JSON - $input", exception)
-        FailedResponse("Failed to parse API response as JSON")
+        FailedResponse(s"Failed to parse API response as JSON: $input\nUnderlying exception - ${exception.getMessage}")
     }
   }
 }


### PR DESCRIPTION
Our preferred logging library is not compatible between Scala 2.10 and versions
above that, so we have decided to have no logging library in this project.