### PR TITLE
fix: Improve robustness when building Codacy API base URL

### DIFF
--- a/src/main/scala/com/codacy/api/client/CodacyClient.scala
+++ b/src/main/scala/com/codacy/api/client/CodacyClient.scala
@@ -3,6 +3,7 @@ package com.codacy.api.client
 import play.api.libs.json._
 import com.codacy.api.util.JsonOps
 import scalaj.http.Http
+import java.net.URL
 
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -25,7 +26,7 @@ class CodacyClient(
     apiToken.map(t => "api_token" -> t) ++
     projectToken.map(t => "project_token" -> t)
 
-  private val remoteUrl = apiUrl.getOrElse("https://api.codacy.com") + "/2.0"
+  private val remoteUrl = new URL(new URL(apiUrl.getOrElse("https://api.codacy.com")), "/2.0").toString()
 
   /*
    * Does an API request and parses the json output into a class


### PR DESCRIPTION
On https://github.com/codacy/docs/issues/404 a user noticed that the upload fails if the defined `CODACY_API_BASE_URL` environment variable includes a trailing slash character (`/`).

By using the java.net.URL constructor we ensure that the version path "/2.0" is always appended after the authority component of the URL.