### PR TITLE
Revert "IO-145 total value removed"

### DIFF
--- a/src/main/scala/com/codacy/api/CoverageReport.scala
+++ b/src/main/scala/com/codacy/api/CoverageReport.scala
@@ -2,9 +2,9 @@ package com.codacy.api
 
 import play.api.libs.json.{JsNumber, JsObject, Json, Writes}
 
-case class CoverageFileReport(filename: String, coverage: Map[Int, Int])
+case class CoverageFileReport(filename: String, total: Int, coverage: Map[Int, Int])
 
-case class CoverageReport(fileReports: Seq[CoverageFileReport])
+case class CoverageReport(total: Int, fileReports: Seq[CoverageFileReport])
 
 object CoverageReport {
   implicit val mapWrites: Writes[Map[Int, Int]] = Writes[Map[Int, Int]] { map: Map[Int, Int] =>


### PR DESCRIPTION
Reverts codacy/codacy-api-scala#51

This is needed since this change cant go in before the backend is not requiring it

We need to push another fix from `codacy-api-scala` to `coverage-reporter` and using the currently published version that includes this change will break sending coverage cc @rubencodacy @OMaluhaCodacy 

Will open a PR with a revert of this revert to be merged when you decide 🙏 