### PR TITLE
Revert "Revert "IO-145 total value removed""

### DIFF
--- a/src/main/scala/com/codacy/api/CoverageReport.scala
+++ b/src/main/scala/com/codacy/api/CoverageReport.scala
@@ -2,9 +2,9 @@ package com.codacy.api
 
 import play.api.libs.json.{JsNumber, JsObject, Json, Writes}
 
-case class CoverageFileReport(filename: String, total: Int, coverage: Map[Int, Int])
+case class CoverageFileReport(filename: String, coverage: Map[Int, Int])
 
-case class CoverageReport(total: Int, fileReports: Seq[CoverageFileReport])
+case class CoverageReport(fileReports: Seq[CoverageFileReport])
 
 object CoverageReport {
   implicit val mapWrites: Writes[Map[Int, Int]] = Writes[Map[Int, Int]] { map: Map[Int, Int] =>


### PR DESCRIPTION
Reverts codacy/codacy-api-scala#53 

the context for this is in the description of #53 

Do not merge until the public api no longer requires the `total` fields